### PR TITLE
Switch to use similar OL package size, add crac feature (optional)

### DIFF
--- a/pom-liberty.xml
+++ b/pom-liberty.xml
@@ -88,7 +88,7 @@
               </bootstrapProperties>
               <runtimeArtifact>
                 <groupId>io.openliberty</groupId>
-                <artifactId>openliberty-runtime</artifactId>
+                <artifactId>openliberty-webProfile10</artifactId>
                 <version>${openliberty.version}</version>
                 <type>zip</type>
               </runtimeArtifact>

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -2,8 +2,9 @@
 <server description="${project.name}">
 
     <featureManager>
-        <feature>jakartaee-10.0</feature>
+        <feature>webProfile-10.0</feature>
         <feature>microProfile-6.1</feature>
+        <feature>crac-1.4</feature>
     </featureManager>
 
     <basicRegistry id="basic" realm="BasicRealm">
@@ -18,6 +19,8 @@
 
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
+
+    <!-- <logging traceSpecification="*=info:com.ibm.ws.app.manager.*=all:com.ibm.ws.threading.internal.*=all" /> -->
 
     <webApplication contextRoot="/" location="randomstrings.war" />
 


### PR DESCRIPTION
Hi - Took a peek at your build, and have a couple suggestions on sizing the package used as comparable to other runtimes in sample.  (webProfile only)

Adding the OL crac-1.4 feature may be optional in your case...   still need to add the api dependency as you do for user app compilation.

Mine is starting in 4.5 sec...  before change it started in 6.5 sec.

If you still see a longer startup time you may need to add a trace string, and look at the resulting trace.log ...  I added a sample trace commented out in server.xml...   Your trace file would show up (~/wlpExtract/randomstrings_xxxx/wlp/usr/servers/randomstrings/logs/trace.log)